### PR TITLE
Add setup script for codex CLI

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+# Install Node.js 22 using n if not already installed
+if ! command -v node >/dev/null || [[ "$(node -v)" != v22* ]]; then
+  npm install -g n
+  n 22
+  export PATH=/usr/local/n/versions/node/*/bin:$PATH
+fi
+
+# Enable corepack and install pnpm
+if ! command -v pnpm >/dev/null; then
+  corepack enable
+  corepack prepare pnpm@10.8.1 --activate
+fi
+
+# Install project dependencies and build the CLI
+pnpm install
+pnpm --filter @openai/codex run build
+
+# Optionally install native sandbox dependencies if GH_TOKEN is set
+if command -v gh >/dev/null && command -v zstd >/dev/null && [[ -n "${GH_TOKEN:-}" ]]; then
+  bash ./codex-cli/scripts/install_native_deps.sh
+else
+  echo "Skipping install_native_deps.sh. Ensure gh, zstd, and GH_TOKEN are available to install sandbox binaries."
+fi
+


### PR DESCRIPTION
## Summary
- add a `setup.sh` helper to bootstrap the Codex CLI

## Testing
- `pnpm test`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6859383de65c8320bfecc9601157f8fb