### PR TITLE
Add --skip-compression for visual screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ Additional options:
 - `--start-cmd` – command used to launch the local server (default `npm start`)
 - `--serve-url` – page URL to screenshot (default `http://localhost:3000`)
 - `--max-attempts` – maximum number of iterations (default `3`)
+- `--skip-compression` – return screenshots without JPEG compression
+  (or set `CODEX_SKIP_COMPRESSION=1`)
 - `OPENAI_API_KEY` must be set for vision evaluation to work
 
 The assistant may also request screenshots at any time using the

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -234,6 +234,10 @@ const cli = meow(
         description: "Maximum visual loop iterations",
         default: 3,
       },
+      skipCompression: {
+        type: "boolean",
+        description: "Return screenshots without JPEG compression",
+      },
     },
   },
 );
@@ -314,6 +318,12 @@ let prompt = cli.input[0];
 const model = cli.flags.model ?? config.model;
 const imagePaths = cli.flags.image;
 const provider = cli.flags.provider ?? config.provider ?? "openai";
+const skipCompression =
+  Boolean(cli.flags.skipCompression) ||
+  process.env["CODEX_SKIP_COMPRESSION"] === "1";
+if (cli.flags.skipCompression) {
+  process.env["CODEX_SKIP_COMPRESSION"] = "1";
+}
 
 const client = {
   issuer: "https://auth.openai.com",
@@ -570,6 +580,7 @@ if (visualLoopMode) {
     startCommand: cli.flags.startCmd,
     url: cli.flags.serveUrl,
     maxAttempts: cli.flags.maxAttempts,
+    skipCompression,
   });
   onExit();
   process.exit(0);

--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -485,6 +485,7 @@ export class AgentLoop {
       const images = await captureScreenshots({
         startCommand: params.start_command,
         url: params.url,
+        skipCompression: process.env["CODEX_SKIP_COMPRESSION"] === "1",
       });
       outputItem.output = JSON.stringify({ images });
     }


### PR DESCRIPTION
## Summary
- allow uncompressed screenshots with `--skip-compression`
- plumb option through visual loop helpers
- respect `CODEX_SKIP_COMPRESSION` env var
- document the new flag in README
- test skipping screenshot compression

## Testing
- `pnpm --filter @openai/codex run lint`
- `pnpm --filter @openai/codex run typecheck`
- `pnpm --filter @openai/codex run test`

------
https://chatgpt.com/codex/tasks/task_e_685974a1969c8320bf9c1bffcd5a9b84